### PR TITLE
Add static build and CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,18 +4,81 @@ on:
   - workflow_dispatch
 
 jobs:
+  x86_64:
+      runs-on: ubuntu-20.04
+      name: Build for ${{ matrix.distro }} x86_64 and mipsle
+      steps:
+      - uses: actions/checkout@v2
 
-  build:
-    runs-on: ubuntu-latest
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Install requirements
+        run: |
+          echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list > /dev/null
+          curl -L https://packagecloud.io/fdio/release/gpgkey | sudo apt-key add -
+          sudo apt-get -y update
+          sudo apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev
+          sudo apt-get install -y wireguard-tools upx-ucl
+
+      - name: Build x86_64
+        run: |
+          make all static vpp
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-x86_64
+          path: etherguard-go*
+
+      - name: Build mipsle
+        run: |
+          make clean
+          GOOS=linux GOARCH=mipsle GOMIPS=softfloat make all static
+          upx -9 etherguard-go*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-mipsle
+          path: etherguard-go*
+
+
+  multi-arch:
+    runs-on: ubuntu-20.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+          - arch: armv7
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Build artifact
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu20.04
+          githubToken: ${{ github.token }}
+          setup: |
+            mkdir -p "${PWD}/artifacts"
+          dockerRunArgs: |
+            --volume "${PWD}/artifacts:/artifacts"
+          env: |
+            artifact_dir: ${{ matrix.arch }}
+          shell: /bin/sh
+          install: |
+            apt-get -y update
+            apt install software-properties-common -y
+            add-apt-repository ppa:longsleep/golang-backports
+            apt-get -y update
+            apt-get install -y wireguard-tools golang-go build-essential git
+          run: |
+            make all static
+            mkdir /artifacts/${artifact_dir}
+            cp etherguard-go* /artifacts/${artifact_dir}
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
-    - name: Install requirements
-      run: sudo apt-get install -y wireguard-tools
-
-    - name: Build
-      run: make
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-multi_arch
+          path: artifacts/

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -69,16 +69,30 @@ jobs:
           shell: /bin/sh
           install: |
             apt-get -y update
-            apt install software-properties-common -y
+
+            apt install software-properties-common curl -y
+
+            echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" > /etc/apt/sources.list.d/99fd.io.list
+            curl -L https://packagecloud.io/fdio/release/gpgkey | apt-key add -
             add-apt-repository ppa:longsleep/golang-backports
+
             apt-get -y update
+            apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev || true
             apt-get install -y wireguard-tools golang-go build-essential git
           run: |
             make all static
+            make vpp || true
             mkdir /artifacts/${artifact_dir}
             cp etherguard-go* /artifacts/${artifact_dir}
 
       - uses: actions/upload-artifact@v2
+        if: ${{ matrix.arch == 'armv7' }}
         with:
-          name: etherguard-multi_arch
-          path: artifacts/
+          name: etherguard-arm32
+          path: artifacts/armv7
+          
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.arch == 'aarch64' }}
+        with:
+          name: etherguard-arm64
+          path: artifacts/aarch64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,133 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  x86_64:
+      runs-on: ubuntu-20.04
+      name: Build for ${{ matrix.distro }} x86_64 and mipsle
+      steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Install requirements
+        run: |
+          echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" | sudo tee -a /etc/apt/sources.list.d/99fd.io.list > /dev/null
+          curl -L https://packagecloud.io/fdio/release/gpgkey | sudo apt-key add -
+          sudo apt-get -y update
+          sudo apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev
+          sudo apt-get install -y wireguard-tools upx-ucl
+
+      - name: Build x86_64
+        run: |
+          make all static vpp
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-x86_64
+          path: etherguard-go*
+
+      - name: Upload x86_64 dynamic build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: etherguard-go
+          asset_name: etherguard-go-x86_64
+          tag: ${{ github.ref }}
+
+      - name: Upload x86_64 static build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: etherguard-go-static
+          asset_name: etherguard-go-static-x86_64
+          tag: ${{ github.ref }}
+
+      - name: Build mipsle
+        run: |
+          make clean
+          GOOS=linux GOARCH=mipsle GOMIPS=softfloat make all static
+          upx -9 etherguard-go*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-mipsle
+          path: etherguard-go*
+
+      - name: Upload mipsle dynamic build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: etherguard-go
+          asset_name: etherguard-go-mipsle
+          tag: ${{ github.ref }}
+
+      - name: Upload mipsle static build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: etherguard-go-static
+          asset_name: etherguard-go-static-mipsle
+          tag: ${{ github.ref }}
+
+  multi-arch:
+    runs-on: ubuntu-20.04
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+          - arch: armv7
+    steps:
+      - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Build artifact
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu20.04
+          githubToken: ${{ github.token }}
+          setup: |
+            mkdir -p "${PWD}/artifacts"
+          dockerRunArgs: |
+            --volume "${PWD}/artifacts:/artifacts"
+          env: |
+            artifact_dir: ${{ matrix.arch }}
+          shell: /bin/sh
+          install: |
+            apt-get -y update
+            apt install software-properties-common -y
+            add-apt-repository ppa:longsleep/golang-backports
+            apt-get -y update
+            apt-get install -y wireguard-tools golang-go build-essential git
+          run: |
+            make all static
+            mkdir /artifacts/${artifact_dir}
+            cp etherguard-go* /artifacts/${artifact_dir}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: etherguard-multi_arch
+          path: artifacts/
+
+      - name: Upload dynamic build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: artifacts/${{ martix.arch }}/etherguard-go
+          asset_name: etherguard-go-${{ martix.arch }}
+          tag: ${{ github.ref }}
+
+      - name: Upload static build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: artifacts/${{ martix.arch }}/etherguard-go-static
+          asset_name: etherguard-go-static-${{ martix.arch }}
+          tag: ${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,14 @@ jobs:
           asset_name: etherguard-go-x86_64
           tag: ${{ github.ref }}
 
+      - name: Upload x86_64 dynamic vpp build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: etherguard-go-vpp
+          asset_name: etherguard-go-x86_64
+          tag: ${{ github.ref }}
+
       - name: Upload x86_64 static build
         uses: svenstaro/upload-release-action@v2
         with:
@@ -67,6 +75,16 @@ jobs:
           file: etherguard-go
           asset_name: etherguard-go-mipsle
           tag: ${{ github.ref }}
+
+
+      - name: Upload mipsle dynamic vpp build
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: etherguard-go-vpp
+          asset_name: etherguard-go-mipsle
+          tag: ${{ github.ref }}
+
 
       - name: Upload mipsle static build
         uses: svenstaro/upload-release-action@v2
@@ -102,21 +120,35 @@ jobs:
           shell: /bin/sh
           install: |
             apt-get -y update
-            apt install software-properties-common -y
+
+            apt install software-properties-common curl -y
+
+            echo "deb [trusted=yes] https://packagecloud.io/fdio/release/ubuntu focal main" > /etc/apt/sources.list.d/99fd.io.list
+            curl -L https://packagecloud.io/fdio/release/gpgkey | apt-key add -
             add-apt-repository ppa:longsleep/golang-backports
+
             apt-get -y update
+            apt-get install -y vpp vpp-plugin-core python3-vpp-api vpp-dbg vpp-dev libmemif libmemif-dev || true
             apt-get install -y wireguard-tools golang-go build-essential git
           run: |
             make all static
+            make vpp || true
             mkdir /artifacts/${artifact_dir}
             cp etherguard-go* /artifacts/${artifact_dir}
 
       - uses: actions/upload-artifact@v2
-        with:
-          name: etherguard-multi_arch
-          path: artifacts/
 
-      - name: Upload dynamic build
+        if: ${{ matrix.arch == 'armv7' }}
+        with:
+          name: etherguard-arm32
+          path: artifacts/armv7
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.arch == 'aarch64' }}
+        with:
+          name: etherguard-arm64
+          path: artifacts/aarch64
+
+      - name: Upload ${{ matrix.arch }} dynamic build
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -124,7 +156,16 @@ jobs:
           asset_name: etherguard-go-${{ martix.arch }}
           tag: ${{ github.ref }}
 
-      - name: Upload static build
+      - name: Upload ${{ matrix.arch }} dynamic vpp build
+        if: ${{ matrix.arch == 'aarch64' }}
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: artifacts/${{ martix.arch }}/etherguard-go
+          asset_name: etherguard-go-${{ martix.arch }}
+          tag: ${{ github.ref }}
+
+      - name: Upload ${{ matrix.arch }} static build
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ etherguard-go: $(wildcard *.go) $(wildcard */*.go)
 	go mod vendor && \
 	go build -v -o "$@"
 
+etherguard-go-static: $(wildcard *.go) $(wildcard */*.go)
+	go mod download && \
+	go mod tidy && \
+	go mod vendor && \
+	CGO_ENABLED=0 go build -a -trimpath -ldflags '-s -w -extldflags "-static"'  -v -o "$@"
+
 vpp:
 	@export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
 	tag="$$(git describe 2>/dev/null)" && \
@@ -39,6 +45,31 @@ etherguard-go-vpp: $(wildcard *.go) $(wildcard */*.go)
 	patch -p0 -i govpp_remove_crcstring_check.patch && \
 	go build -v -tags vpp -o "$@"
 
+etherguard-go-vpp-static: $(wildcard *.go) $(wildcard */*.go)
+	go mod download && \
+	go mod tidy && \
+	go mod vendor && \
+	patch -p0 -i govpp_remove_crcstring_check.patch && \
+	CGO_ENABLED=0 go build -trimpath -a -ldflags '-s -w -extldflags "-static"'  -v -tags vpp -o "$@"
+
+static:
+	@export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
+	tag="$$(git describe 2>/dev/null)" && \
+	ver="$$(printf 'package main\n\nconst Version = "%s"\n' "$$tag")" && \
+	[ "$$(cat version.go 2>/dev/null)" != "$$ver" ] && \
+	echo "$$ver" > version.go && \
+	git update-index --assume-unchanged version.go || true
+	@$(MAKE) etherguard-go-static
+
+static-vpp:
+	@export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
+	tag="$$(git describe 2>/dev/null)" && \
+	ver="$$(printf 'package main\n\nconst Version = "%s"\n' "$$tag")" && \
+	[ "$$(cat version.go 2>/dev/null)" != "$$ver" ] && \
+	echo "$$ver" > version.go && \
+	git update-index --assume-unchanged version.go || true
+	@$(MAKE) etherguard-go-vpp-static
+
 install: etherguard-go
 	@install -v -d "$(DESTDIR)$(BINDIR)" && install -v -m 0755 "$<" "$(DESTDIR)$(BINDIR)/etherguard-go"
 
@@ -47,6 +78,8 @@ test:
 
 clean:
 	rm -f etherguard-go
+	rm -f etherguard-go-static
 	rm -f etherguard-go-vpp
+	rm -f etherguard-go-vpp-static
 
 .PHONY: all clean test install generate-version-and-build

--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,6 @@ etherguard-go-vpp: $(wildcard *.go) $(wildcard */*.go)
 	patch -p0 -i govpp_remove_crcstring_check.patch && \
 	go build -v -tags vpp -o "$@"
 
-etherguard-go-vpp-static: $(wildcard *.go) $(wildcard */*.go)
-	go mod download && \
-	go mod tidy && \
-	go mod vendor && \
-	patch -p0 -i govpp_remove_crcstring_check.patch && \
-	CGO_ENABLED=0 go build -trimpath -a -ldflags '-s -w -extldflags "-static"'  -v -tags vpp -o "$@"
-
 static:
 	@export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
 	tag="$$(git describe 2>/dev/null)" && \
@@ -60,15 +53,6 @@ static:
 	echo "$$ver" > version.go && \
 	git update-index --assume-unchanged version.go || true
 	@$(MAKE) etherguard-go-static
-
-static-vpp:
-	@export GIT_CEILING_DIRECTORIES="$(realpath $(CURDIR)/..)" && \
-	tag="$$(git describe 2>/dev/null)" && \
-	ver="$$(printf 'package main\n\nconst Version = "%s"\n' "$$tag")" && \
-	[ "$$(cat version.go 2>/dev/null)" != "$$ver" ] && \
-	echo "$$ver" > version.go && \
-	git update-index --assume-unchanged version.go || true
-	@$(MAKE) etherguard-go-vpp-static
 
 install: etherguard-go
 	@install -v -d "$(DESTDIR)$(BINDIR)" && install -v -m 0755 "$<" "$(DESTDIR)$(BINDIR)/etherguard-go"


### PR DESCRIPTION
This PR provides following features:  
* statically linked build to `Makefile`.  
* Github Action workflow to upload build results on multiple arch when publish a new release.  

You can build statically linked executables by using `make static` and `make vpp-statc`.  

Following arch are supported in workflow:   
|   | no-vpp version, dynamic  | no-vpp version, static | vpp version, dynamic| vpp version, static |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| x86_64  | ✔️ | ✔️ | ✔️ | ⛔ |
| mipsle   | ✔️ | ✔️ | ⛔ | ⛔ |
| aarch64 | ✔️ | ✔️ | ✔️ | ⛔ |
| armv7   | ✔️ | ✔️ | ⛔  | ⛔ |

## Known issues
* `make vpp-static` will fail in the workflow.